### PR TITLE
Use recommended way of ansible_managed comment

### DIFF
--- a/templates/checksum_catalog.yml.j2
+++ b/templates/checksum_catalog.yml.j2
@@ -1,4 +1,4 @@
-# {{ ansible_managed }}
+{{ ansible_managed | ansible.builtin.comment }}
 
 sssd_build_options: {{ sssd_build_options | hash('sha1') }}
 sssd_download_url: {{ sssd_download_url | hash('sha1') }}

--- a/templates/sssd.conf.j2
+++ b/templates/sssd.conf.j2
@@ -1,4 +1,4 @@
-# {{ ansible_managed }}
+{{ ansible_managed | ansible.builtin.comment }}
 
 {% for section in sssd_config.keys() %}
 [{{ section }}]

--- a/templates/sssd.init-Debian.j2
+++ b/templates/sssd.init-Debian.j2
@@ -1,5 +1,5 @@
 #!/bin/sh
-# {{ ansible_managed }}
+{{ ansible_managed | ansible.builtin.comment }}
 #
 ### BEGIN INIT INFO
 # Provides:          sssd

--- a/templates/sssd.init-RedHat.j2
+++ b/templates/sssd.init-RedHat.j2
@@ -1,5 +1,5 @@
 #!/bin/sh
-# {{ ansible_managed }}
+{{ ansible_managed | ansible.builtin.comment }}
 #
 #
 # chkconfig: - 12 88

--- a/templates/sssd.service-Debian.j2
+++ b/templates/sssd.service-Debian.j2
@@ -1,4 +1,4 @@
-# {{ ansible_managed }}
+{{ ansible_managed | ansible.builtin.comment }}
 # Service enabled: {{ sssd_service_enabled | default('yes') }}
 [Unit]
 Description=System Security Services Daemon

--- a/templates/sssd.service-RedHat.j2
+++ b/templates/sssd.service-RedHat.j2
@@ -1,4 +1,4 @@
-# {{ ansible_managed }}
+{{ ansible_managed | ansible.builtin.comment }}
 # Service enabled: {{ sssd_service_enabled | default('yes') }}
 [Unit]
 Description=System Security Services Daemon


### PR DESCRIPTION
The current method does not work if ansible_managed is multiline string.
We are facing this exact issue here:
https://gitlab.psi.ch/lsm-hpce/alps/ansible-psidev/-/merge_requests/194

This change will properly comment the ansible_managed value even if it is a multiline value.